### PR TITLE
Subfolder parameters for google-iot-core out node

### DIFF
--- a/google-iot-core.html
+++ b/google-iot-core.html
@@ -99,6 +99,10 @@ message store.</p>
         <label for="node-input-name"><i class="fa fa-tag"></i> <span data-i18n="google-iot-core.label.name"></span></label>
         <input type="text" id="node-input-name" data-i18n="[placeholder]google-iot-core.label.name">
     </div>
+    <div class="form-row">
+        <label for="node-input-subfolder"><i class="fa fa-folder"></i> <span data-i18n="google-iot-core.label.subfolder"></span></label>
+        <input type="text" id="node-input-subfolder" data-i18n="[placeholder]google-iot-core.label.subfolder">
+    </div>
     <div class="form-tips"><span data-i18n="google-iot-core.tip"></span></div>
 </script>
 

--- a/google-iot-core.html
+++ b/google-iot-core.html
@@ -124,6 +124,10 @@ message store.</p>
 
        <dt class="optional">retain <span class="property-type">boolean</span></dt>
        <dd>set to true to retain the message on the broker. Default false.</dd>
+
+       <dt class="optional">subfolder <span class="property-type">string</span></dt>
+       <dd>subfolder for telemetry events.</dd>
+
     </dl>
     <h3>Details</h3>
     <code>msg.payload</code> is used as the payload of the published message.

--- a/google-iot-core.html
+++ b/google-iot-core.html
@@ -72,6 +72,11 @@ message store.</p>
             if (this.qos === undefined) {
                 $("#node-input-qos").val("2");
             }
+        },
+        oneditprepare: function() {
+            if (this.subfolder === undefined) {
+                $("#node-input-subfolder").val("");
+            }
         }
     });
 </script>
@@ -137,6 +142,7 @@ message store.</p>
         category: 'output',
         defaults: {
             name: {value:""},
+            subfolder: {value:""},
             qos: {value:""},
             retain: {value:""},
             broker: {type:"google-iot-core-broker", required:true}

--- a/google-iot-core.js
+++ b/google-iot-core.js
@@ -403,8 +403,14 @@ module.exports = function (RED) {
         this.qos = n.qos || null;
         this.retain = n.retain;
         this.broker = n.broker;
+        this.subfolder = n.subfolder;
         this.brokerConn = RED.nodes.getNode(this.broker);
-        this.topic = '/devices/' + this.brokerConn.deviceid + '/events';
+
+        if (strValue) {
+            this.topic = '/devices/' + this.brokerConn.deviceid + '/events/' + this.subfolder;
+        } else {
+            this.topic = '/devices/' + this.brokerConn.deviceid + '/events';
+        }
         var node = this;
 
         if (this.brokerConn) {

--- a/google-iot-core.js
+++ b/google-iot-core.js
@@ -406,7 +406,7 @@ module.exports = function (RED) {
         this.subfolder = n.subfolder;
         this.brokerConn = RED.nodes.getNode(this.broker);
 
-        if (strValue) {
+        if (this.subfolder) {
             this.topic = '/devices/' + this.brokerConn.deviceid + '/events/' + this.subfolder;
         } else {
             this.topic = '/devices/' + this.brokerConn.deviceid + '/events';

--- a/locales/en-US/google-iot-core.json
+++ b/locales/en-US/google-iot-core.json
@@ -15,6 +15,7 @@
             "verify-server-cert":"Verify server certificate",
             "topic": "Topic",
             "name": "Name",
+            "subfolder": "Subfolder",
             "payload": "Payload",
             "persistout": "Persist outgoing messages",         
             "persistin": "Incoming messages",            

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "node-red-contrib-google-iot-core",
-  "version": "0.0.4",
+  "version": "0.0.5",
   "description": "MQTT Node with persistent message storage for Google IoT core",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"


### PR DESCRIPTION
Hi,

First of all, thanks a lot for the excellent job in this project.

During the use of it I noted that you mqtt topic only permit the /events one, that corresponds to the main telemetry topic. Nevertheless, IoT Core can have multiple telemetry events what is very useful for the organization of different messages. Normally I have a /events/alarms subfolder that is specific for this alarms and warnings.

So I proposed this simple modification in your code.

Regards

Jaime